### PR TITLE
fix: update init command to restart after configuration is done

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -166,8 +166,8 @@ func NewZapConfigInteractive(configPath string) (*Store, error) {
 		return nil, err
 	}
 
+	autoUpdateEnabled := false
 	if _, err = os.Stat("/etc/systemd/user/zapd.service"); os.IsNotExist(err) {
-		autoUpdateEnabled := false
 		autoUpdateEnabledPrompt := &survey.Confirm{
 			Message: "Do you want to enable auto-update?",
 			Help:    "Auto update will install a systemd service which will periodically check for updates and install the latest version.",
@@ -175,12 +175,6 @@ func NewZapConfigInteractive(configPath string) (*Store, error) {
 		err = survey.AskOne(autoUpdateEnabledPrompt, &autoUpdateEnabled)
 		if err != nil {
 			return nil, err
-		}
-		if autoUpdateEnabled {
-			err = daemon.SetupToRunThroughSystemd()
-			if err != nil {
-				return nil, err
-			}
 		}
 	}
 
@@ -254,5 +248,14 @@ func NewZapConfigInteractive(configPath string) (*Store, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// If auto update was enabled, we (re-)start with systemd
+	if autoUpdateEnabled {
+		err := daemon.SetupToRunThroughSystemd()
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return cfg, nil
 }

--- a/daemon/systemd.go
+++ b/daemon/systemd.go
@@ -126,8 +126,6 @@ func SetupToRunThroughSystemd() error {
 			if err != nil {
 				logger.Debug(prc.String())
 				logger.Debug(err)
-			} else {
-				os.Exit(0)
 			}
 		} else {
 			logger.Infof("Enabling systemd service...")


### PR DESCRIPTION
Addresses #89.

I am unsure exactly what the logic should be here but, based on the issue description, it seems like the call to `os.Exit()` in `SetupToRunThroughSystemd()` ends the configuration prematurely. My guess is that instead, the whole configuration should be set and then the program should be restarted through systemd afterwards.